### PR TITLE
ACADEMY-716 Add OSGi configuration samples

### DIFF
--- a/action-samples/README.md
+++ b/action-samples/README.md
@@ -10,7 +10,7 @@ This repository contains samples of Jahia Action declared with OSGi
 
 Simple action:
 ```shell script
-response=$(curl -s -X GET http://localhost:8080/yourContextIfOne/en/sites/youSiteKey.simpleAction.do -H 'accept: application/json') && echo $response
+response=$(curl -s -X POST http://localhost:8080/en/sites/SITE_KEY.simpleAction.do -H 'accept: application/json') && echo $response
 
 ## Output >
 ## {"message":"Hello Jahia!"}
@@ -18,7 +18,7 @@ response=$(curl -s -X GET http://localhost:8080/yourContextIfOne/en/sites/youSit
 
 Advanced action:
 ```shell script
-response=$(curl -s -u root:root1234 -X GET http://localhost:8080/yourContextIfOne/en/sites/youSiteKey.advancedAction.do -H 'accept: application/json') && echo $response
+response=$(curl -s -u root:root1234 -X POST http://localhost:8080/en/sites/SITE_KEY.advancedAction.do -H 'accept: application/json') && echo $response
 
 ## Output something like >
 ## {"message":"Hello Jahia there are X modules on this site","modules":[]}

--- a/action-samples/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-actionsamples.cfg
+++ b/action-samples/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-actionsamples.cfg
@@ -1,0 +1,1 @@
+whitelist = *.simpleAction.do,*.advancedAction.do

--- a/auth-valve/pom.xml
+++ b/auth-valve/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.2.0-SNAPSHOT</version>
+        <version>8.0.3.0</version>
     </parent>
 
     <artifactId>auth-valve</artifactId>

--- a/config-samples/README.md
+++ b/config-samples/README.md
@@ -1,0 +1,10 @@
+# OSGi modules configuration samples
+
+This project contains examples of how to use configuration with OSGi modules. All the examples use Declarative Services annotations, which is the recommended way of building Jahia Modules. You can find the following examples:
+
+- SimpleConfigExample: a basic as-simple-as-it-gets example of OSGi module configuration
+- YamlConfigExample: an example of a module complex structure of configuration
+- Metatype: an example of how to add metatype information to your configuration, which makes it a better experience when using OSGi Config Admin UIs such as the Felix Web Console
+- Factory: an example of how to build configurations for factories, and in this case we also show how to use factories to build site-specific configurations.
+
+

--- a/config-samples/pom.xml
+++ b/config-samples/pom.xml
@@ -7,15 +7,15 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.1.2.0</version>
     </parent>
 
-    <artifactId>servlet-filter-samples</artifactId>
+    <artifactId>config-samples</artifactId>
     <groupId>org.foo.modules</groupId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>Jahia Servlet filter samples</name>
-    <description>This is a module with Jahia servlet filter samples</description>
+    <name>Jahia OSGi Configuration samples</name>
+    <description>This is a module with Jahia OSGi Configuration samples</description>
 
     <scm>
         <connection>scm:git:git@github.com:Jahia/OSGi-modules-samples.git</connection>

--- a/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/SiteConfig.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/SiteConfig.java
@@ -1,0 +1,12 @@
+package org.foo.modules.samples.config.factory.site;
+
+/**
+ * The interface for the site configuration service
+ */
+public interface SiteConfig {
+
+    String getKey();
+
+    String getType();
+
+}

--- a/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/SiteConfigConsumer.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/SiteConfigConsumer.java
@@ -1,0 +1,33 @@
+package org.foo.modules.samples.config.factory.site;
+
+import org.osgi.service.component.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An example of a consumer for the site configuration service example.
+ */
+@Component
+public class SiteConfigConsumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(SiteConfigConsumer.class);
+
+    private List<SiteConfig> siteConfigs = new ArrayList<>();
+
+    // The GREEDY policy makes sure that ALL the instances of the configuration are instantiated, otherwise only one would be created.
+    // Making it DYNAMIC also avoids the component to activate/deactivate for each config binding.
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    public void addSiteConfig(SiteConfig siteConfig) {
+        this.siteConfigs.add(siteConfig);
+        logger.info("Adding site key={} type={}", siteConfig.getKey(), siteConfig.getType());
+    }
+
+    public void removeSiteConfig(SiteConfig siteConfig) {
+        this.siteConfigs.remove(siteConfig);
+        logger.info("Removing site key={}", siteConfig.getKey());
+    }
+
+}

--- a/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/internal/SiteConfigImpl.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/internal/SiteConfigImpl.java
@@ -1,0 +1,44 @@
+package org.foo.modules.samples.config.factory.site.internal;
+
+import org.foo.modules.samples.config.factory.site.SiteConfig;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.*;
+
+/**
+ * An example of a component using a configuration for component factories also using metatypes. The configuration files are
+ * located in src/main/resources/META-INF/configurations/org.foo.modules.samples.config.factory.site-*.cfg
+ */
+@Component(service = {SiteConfig.class}, configurationPid = "org.foo.modules.samples.config.factory.site")
+@Designate(ocd = SiteConfigImpl.Config.class)
+public class SiteConfigImpl implements SiteConfig {
+
+    private Config config;
+
+    @ObjectClassDefinition(name = "Site configuration", description = "A configuration for a site")
+    public @interface Config {
+
+        @AttributeDefinition(name = "Site key", defaultValue = "siteKey", description = "The identifier for the site")
+        String key() default "siteKey";
+
+        // Dropdown
+        @AttributeDefinition(name = "Site type", options = { @Option(label = "Landing page", value = "landing"),
+                @Option(label = "Marketing", value = "marketing"), @Option(label = "Support", value = "support") })
+        String type() default "marketing";
+    }
+
+    @Activate
+    public void activate(final Config config) {
+        this.config = config;
+    }
+
+    @Override
+    public String getKey() {
+        return config.key();
+    }
+
+    @Override
+    public String getType() {
+        return config.type();
+    }
+}

--- a/config-samples/src/main/java/org/foo/modules/samples/config/metatype/MetatypeConfigExample.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/metatype/MetatypeConfigExample.java
@@ -1,0 +1,42 @@
+package org.foo.modules.samples.config.metatype;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.osgi.service.metatype.annotations.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An example of a component using a metatype configuration. The configuration file is
+ * located in src/main/resources/META-INF/configurations/org.foo.modules.samples.config.metatype.example.cfg
+ */
+@Component(configurationPid = "org.foo.modules.samples.config.metatype.example", immediate = true)
+@Designate(ocd = MetatypeConfigExample.Config.class)
+public class MetatypeConfigExample {
+
+    private static final Logger logger = LoggerFactory.getLogger(MetatypeConfigExample.class);
+
+    @ObjectClassDefinition(name = "Metatype configuration", description = "An example of configuration with metatype")
+    public @interface Config {
+        @AttributeDefinition(name = "Simple key", defaultValue = "nokey", description = "Simple key value")
+        String key() default "nokey";
+
+        // Dropdown
+        @AttributeDefinition(name = "Dropdown", options = { @Option(label = "Option 1", value = "option1"),
+                @Option(label = "Option 2", value = "option 2"), @Option(label = "Option 3", value = "option3") })
+        String dropdown() default "option1";
+
+        @AttributeDefinition(name = "Values.test1", defaultValue = "none", description="Key with . character in it")
+        String values_test1() default "none";
+    }
+
+    @Activate
+    public void activate(Config config) {
+        logger.info("key={}", config.key());
+        logger.info("dropdown={}", config.dropdown());
+        logger.info("values.test1={}", config.values_test1());
+    }
+}

--- a/config-samples/src/main/java/org/foo/modules/samples/config/simple/SimpleConfigExample.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/simple/SimpleConfigExample.java
@@ -1,0 +1,25 @@
+package org.foo.modules.samples.config.simple;
+
+import org.foo.modules.samples.config.yaml.YamlConfigExample;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * A very basic example of a component using a configuration. The configuration file is
+ * located in src/main/resources/META-INF/configurations/org.foo.modules.samples.config.simple.example.cfg
+ */
+@Component(configurationPid="org.foo.modules.samples.config.simple.example", immediate=true)
+public class SimpleConfigExample {
+    private static final Logger logger = LoggerFactory.getLogger(SimpleConfigExample.class);
+
+    @Activate
+    public void activate(Map<String, ?> properties) {
+        for (String key : properties.keySet()) {
+            logger.info("{} : {}", key, properties.get(key));
+        }
+    }
+}

--- a/config-samples/src/main/java/org/foo/modules/samples/config/yaml/YamlConfigExample.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/yaml/YamlConfigExample.java
@@ -1,0 +1,25 @@
+package org.foo.modules.samples.config.yaml;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * An example of a component using a YAML configuration. The configuration file is
+ * located in src/main/resources/META-INF/configurations/org.foo.modules.samples.config.yaml.example.cfg
+ */
+@Component(configurationPid="org.foo.modules.samples.config.yaml.example", immediate=true)
+public class YamlConfigExample {
+
+    private static final Logger logger = LoggerFactory.getLogger(YamlConfigExample.class);
+
+    @Activate
+    public void activate(Map<String, ?> properties) {
+        for (String key : properties.keySet()) {
+            logger.info("{} : {}", key, properties.get(key));
+        }
+    }
+}

--- a/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.factory.site-digitall.cfg
+++ b/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.factory.site-digitall.cfg
@@ -1,0 +1,2 @@
+key=digitall
+type=marketing

--- a/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.factory.site-mysite.cfg
+++ b/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.factory.site-mysite.cfg
@@ -1,0 +1,2 @@
+key=mySite
+type=landing

--- a/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.metatype.example.cfg
+++ b/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.metatype.example.cfg
@@ -1,0 +1,6 @@
+# default configuration
+key=customChoiceList1
+dropdown=option2
+values.test1=Test 1
+values.test2=Test 2
+values.test3=Test 3

--- a/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.simple.example.cfg
+++ b/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.simple.example.cfg
@@ -1,0 +1,4 @@
+key=customChoiceList1
+values.test1=Test 1
+values.test2=Test 2
+values.test3=Test 3

--- a/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.yaml.example.yaml
+++ b/config-samples/src/main/resources/META-INF/configurations/org.foo.modules.samples.config.yaml.example.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  labels:
+    app: my-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: my-app
+          image: my-app:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: ENV
+              value: prod
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+            requests:
+              cpu: "0.5"
+              memory: "512Mi"
+        - name: sidecar
+          image: my-sidecar:latest
+          env:
+            - name: ENV
+              value: prod
+      initContainers:
+        - name: init-my-db
+          image: busybox
+          command: ['sh', '-c', 'until nslookup my-db; do echo waiting for my-db; sleep 2; done;']
+        - name: init-my-config
+          image: busybox
+          command: ['sh', '-c', 'until nslookup my-config; do echo waiting for my-config; sleep 2; done;']
+      volumes:
+        - name: config-volume
+          configMap:
+            name: my-config
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: my-pv-claim


### PR DESCRIPTION
Lots of new OSGi configuration samples:
- SimpleConfigExample: a basic as-simple-as-it-gets example of OSGi module configuration
- YamlConfigExample: an example of a module complex structure of configuration
- Metatype: an example of how to add metatype information to your configuration, which makes it a better experience when using OSGi Config Admin UIs such as the Felix Web Console
- Factory: an example of how to build configurations for factories, and in this case we also show how to use factories to build site-specific configurations.
