### PR TITLE
ACADEMY-716 Improve metatype examples

### DIFF
--- a/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/internal/SiteConfigImpl.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/factory/site/internal/SiteConfigImpl.java
@@ -3,27 +3,28 @@ package org.foo.modules.samples.config.factory.site.internal;
 import org.foo.modules.samples.config.factory.site.SiteConfig;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.metatype.annotations.*;
 
 /**
  * An example of a component using a configuration for component factories also using metatypes. The configuration files are
  * located in src/main/resources/META-INF/configurations/org.foo.modules.samples.config.factory.site-*.cfg
  */
-@Component(service = {SiteConfig.class}, configurationPid = "org.foo.modules.samples.config.factory.site")
-@Designate(ocd = SiteConfigImpl.Config.class)
+@Component(service = {SiteConfig.class}, configurationPid = "org.foo.modules.samples.config.factory.site", configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Designate(ocd = SiteConfigImpl.Config.class, factory = true)
 public class SiteConfigImpl implements SiteConfig {
 
     private Config config;
 
-    @ObjectClassDefinition(name = "Site configuration", description = "A configuration for a site")
+    @ObjectClassDefinition(name = "%siteConfiguration", description = "%siteConfigurationDescription", localization = "OSGI-INF/l10n/siteconfig")
     public @interface Config {
 
-        @AttributeDefinition(name = "Site key", defaultValue = "siteKey", description = "The identifier for the site")
+        @AttributeDefinition(name = "%siteKey", defaultValue = "siteKey", description = "%siteKeyDescription")
         String key() default "siteKey";
 
         // Dropdown
-        @AttributeDefinition(name = "Site type", options = { @Option(label = "Landing page", value = "landing"),
-                @Option(label = "Marketing", value = "marketing"), @Option(label = "Support", value = "support") })
+        @AttributeDefinition(name = "%siteType", options = { @Option(label = "%siteType.landingPage", value = "landing"),
+                @Option(label = "%siteType.marketing", value = "marketing"), @Option(label = "%siteType.support", value = "support") })
         String type() default "marketing";
     }
 

--- a/config-samples/src/main/java/org/foo/modules/samples/config/metatype/MetatypeConfigExample.java
+++ b/config-samples/src/main/java/org/foo/modules/samples/config/metatype/MetatypeConfigExample.java
@@ -19,17 +19,17 @@ public class MetatypeConfigExample {
 
     private static final Logger logger = LoggerFactory.getLogger(MetatypeConfigExample.class);
 
-    @ObjectClassDefinition(name = "Metatype configuration", description = "An example of configuration with metatype")
+    @ObjectClassDefinition(name = "%metatypeConfiguration", description = "%metatypeConfigurationDescription", localization = "OSGI-INF/l10n/metatypeExample")
     public @interface Config {
-        @AttributeDefinition(name = "Simple key", defaultValue = "nokey", description = "Simple key value")
+        @AttributeDefinition(name = "%simpleKey", defaultValue = "nokey", description = "%simpleKeyDescription")
         String key() default "nokey";
 
         // Dropdown
-        @AttributeDefinition(name = "Dropdown", options = { @Option(label = "Option 1", value = "option1"),
-                @Option(label = "Option 2", value = "option 2"), @Option(label = "Option 3", value = "option3") })
+        @AttributeDefinition(name = "%dropdown", options = { @Option(label = "%dropdown.option1", value = "option1"),
+                @Option(label = "%dropdown.option2", value = "option 2"), @Option(label = "%dropdown.option3", value = "option3") })
         String dropdown() default "option1";
 
-        @AttributeDefinition(name = "Values.test1", defaultValue = "none", description="Key with . character in it")
+        @AttributeDefinition(name = "%values.test1", defaultValue = "none", description="%values.test1.description")
         String values_test1() default "none";
     }
 

--- a/config-samples/src/main/resources/OSGI-INF/l10n/metatypeExample.properties
+++ b/config-samples/src/main/resources/OSGI-INF/l10n/metatypeExample.properties
@@ -1,0 +1,10 @@
+metatypeConfiguration=Metatype configuration
+metatypeConfigurationDescription=An example of configuration with metatype
+simpleKey=Simple key
+simpleKeyDescription=
+dropdown=Dropdown
+dropdown.option1=Option 1
+dropdown.option2=Option 2
+dropdown.option3=Option 3
+values.test1=values.test1
+values.test1.description=Key with . character in it

--- a/config-samples/src/main/resources/OSGI-INF/l10n/siteconfig.properties
+++ b/config-samples/src/main/resources/OSGI-INF/l10n/siteconfig.properties
@@ -1,0 +1,8 @@
+siteConfiguration=Site configuration
+siteConfigurationDescription=A configuration for a site
+siteKey=Site key
+siteKeyDescription=The identifier for the site
+siteType=Site type
+siteType.landingPage=Landing page
+siteType.marketing=Marketing
+siteType.support=Support


### PR DESCRIPTION
- Add resource bundle keys
- Add factory configuration for designate to get factories to work in OSGi Web Console Config Admin UI
- Add configuration policy to require a configuration instead of the default that is optional.
