### PR TITLE
BACKLOG-22429 JahiaEventListener interface improvements

### DIFF
--- a/jahia-event-listener/src/main/java/org/foo/modules/listener/CustomEventProducer.java
+++ b/jahia-event-listener/src/main/java/org/foo/modules/listener/CustomEventProducer.java
@@ -1,0 +1,77 @@
+package org.foo.modules.listener;
+
+import org.jahia.params.valves.BaseLoginEvent;
+import org.jahia.services.observation.JahiaEventService;
+import org.jahia.services.usermanager.JahiaUser;
+import org.jahia.services.usermanager.JahiaUserImpl;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A custom event producer class that defines a new custom login event types and produces instances of it every
+ * 10 seconds. This serves as an example on how to create custom event types and how to inject them into the
+ * event service as well.
+ */
+@Component(immediate=true)
+public class CustomEventProducer {
+
+    private final static Logger logger = LoggerFactory.getLogger(TestEventListener.class);
+
+    private JahiaEventService jahiaEventService;
+    private AtomicBoolean active = new AtomicBoolean(false);
+
+    private ScheduledExecutorService executor;
+
+    @Reference
+    public void setJahiaEventService(JahiaEventService jahiaEventService) {
+        this.jahiaEventService = jahiaEventService;
+    }
+
+    public void produceEvents() {
+        try {
+            while (active.get()) {
+                jahiaEventService.publishEvent(new CustomLoginEvent(this, new JahiaUserImpl("testUser", "/users/testUser", new Properties(), "customRealm")));
+                Thread.sleep(10000); // 10 seconds
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Activate
+    public void activate(BundleContext context) {
+        logger.info("Starting custom event producer...");
+        executor = Executors.newSingleThreadScheduledExecutor();
+        active.set(true);
+
+        Runnable task = this::produceEvents;
+
+        executor.scheduleAtFixedRate(task, 0, 2, TimeUnit.SECONDS);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        logger.info("Shutting down custom event producer...");
+        active.set(false);
+        executor.shutdown();
+        executor = null;
+    }
+
+    private class CustomLoginEvent extends BaseLoginEvent {
+        public CustomLoginEvent(Object source, JahiaUser jahiaUser) {
+            super(source, jahiaUser, null);
+        }
+    }
+
+}

--- a/jahia-event-listener/src/main/java/org/foo/modules/listener/TestEventListener.java
+++ b/jahia-event-listener/src/main/java/org/foo/modules/listener/TestEventListener.java
@@ -12,8 +12,17 @@ import java.util.EventObject;
 public class TestEventListener implements JahiaEventListener<BaseLoginEvent> {
     private final static Logger logger = LoggerFactory.getLogger(TestEventListener.class);
 
+    private static final Class<BaseLoginEvent>[] ALLOWED_EVENT_TYPES = new Class[]{BaseLoginEvent.class};
+
     @Override
     public void onEvent(EventObject event) {
-        logger.info("Received event : "+event);
+        // We can perform this cast because we said we only wanted to receive BaseLoginEvent and subclasses of it
+        BaseLoginEvent baseLoginEvent = (BaseLoginEvent) event;
+        logger.info("Received login event : class={} user={}", event.getClass().getName(), baseLoginEvent.getJahiaUser().getUserKey());
+    }
+
+    @Override
+    public Class<BaseLoginEvent>[] getEventTypes() {
+        return ALLOWED_EVENT_TYPES;
     }
 }


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22429

## Description

- Modified the existing TestEventListener to implement the new getEventTypes method that returns the list of event types that the listener is interested in
- Made the event handler method (onEvent) a little more interesting by casting the event to the listened type and producing output using the specific event information
- Added a new CustomEventProducer example class that defines a new CustomLoginEvent and produces instances of it every 10 seconds. This example serves both as a test case for the event system as well as an example on how to implement custom event types and produce them in the JahiaEventService.

