### PR TITLE
QA-15101 Remove manual registration of JCR Event listeners.

### DIFF
--- a/action-samples/pom.xml
+++ b/action-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>action-samples</artifactId>

--- a/auth-valve/pom.xml
+++ b/auth-valve/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.3.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>auth-valve</artifactId>

--- a/background-job-samples/pom.xml
+++ b/background-job-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>background-job-samples</artifactId>

--- a/cache-key-part-generator-samples/pom.xml
+++ b/cache-key-part-generator-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>cache-key-part-generator-samples</artifactId>

--- a/choicelist-samples/pom.xml
+++ b/choicelist-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>choicelist-samples</artifactId>

--- a/choicelist-samples/src/main/java/org/foo/modules/choicelists/SimpleChoiceListInitializer.java
+++ b/choicelist-samples/src/main/java/org/foo/modules/choicelists/SimpleChoiceListInitializer.java
@@ -49,7 +49,7 @@ public class SimpleChoiceListInitializer implements ModuleChoiceListInitializer 
 
     @Override
     public List<ChoiceListValue> getChoiceListValues(ExtendedPropertyDefinition extendedPropertyDefinition, String s, List<ChoiceListValue> list, Locale locale, Map<String, Object> map) {
-        Set<Map.Entry<String,String>> set = values.getMap().entrySet();
-        return set.stream().map(entry -> new ChoiceListValue(entry.getValue(), entry.getKey())).collect(Collectors.toList());
+        Set<Map.Entry<String, Object>> set = values.getMap().entrySet();
+        return set.stream().map(entry -> new ChoiceListValue(entry.getValue().toString(), entry.getKey())).collect(Collectors.toList());
     }
 }

--- a/config-samples/pom.xml
+++ b/config-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.2.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>config-samples</artifactId>

--- a/filter-samples/pom.xml
+++ b/filter-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>filter-samples</artifactId>

--- a/filter-samples/src/main/java/org/foo/modules/filters/AdvancedFilter.java
+++ b/filter-samples/src/main/java/org/foo/modules/filters/AdvancedFilter.java
@@ -7,7 +7,6 @@ import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
 import org.jahia.services.render.filter.RenderFilter;
 import org.jahia.services.sites.JahiaSitesService;
-import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -57,7 +56,6 @@ public class AdvancedFilter extends AbstractFilter {
      * @param output    Original output to modify
      * @return          Modified output
      */
-    @NotNull
     private String enhanceOutput(String output) {
         Source source = new Source(output);
         OutputDocument outputDocument = new OutputDocument(source);

--- a/filter-samples/src/main/java/org/foo/modules/filters/SimpleFilter.java
+++ b/filter-samples/src/main/java/org/foo/modules/filters/SimpleFilter.java
@@ -6,7 +6,6 @@ import org.jahia.services.render.Resource;
 import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
 import org.jahia.services.render.filter.RenderFilter;
-import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
@@ -48,7 +47,6 @@ public class SimpleFilter extends AbstractFilter {
      * @param output    Original output to modify
      * @return          Modified output
      */
-    @NotNull
     private String enhanceOutput(String output) {
         Source source = new Source(output);
         OutputDocument outputDocument = new OutputDocument(source);

--- a/interceptor-samples/pom.xml
+++ b/interceptor-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>interceptor-samples</artifactId>

--- a/jahia-event-listener/pom.xml
+++ b/jahia-event-listener/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>jahia-event-listener</artifactId>

--- a/login-provider/pom.xml
+++ b/login-provider/pom.xml
@@ -7,8 +7,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.3.0</version>
-        <relativePath />
+        <version>8.2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>login-provider</artifactId>

--- a/login-provider/pom.xml
+++ b/login-provider/pom.xml
@@ -8,6 +8,7 @@
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
         <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>login-provider</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.3.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/rules-samples/pom.xml
+++ b/rules-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>rules-samples</artifactId>
@@ -23,10 +24,6 @@
         <url>https://github.com/Jahia/OSGi-modules-samples</url>
         <tag>HEAD</tag>
     </scm>
-
-    <properties>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
-    </properties>
 
     <repositories>
         <repository>

--- a/rules-samples/src/main/java/org/foo/modules/rules/CustomJCREventListener.java
+++ b/rules-samples/src/main/java/org/foo/modules/rules/CustomJCREventListener.java
@@ -1,12 +1,7 @@
 package org.foo.modules.rules;
 
-import org.jahia.api.Constants;
-import org.jahia.api.templates.JahiaTemplateManagerService;
 import org.jahia.services.content.DefaultEventListener;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,28 +13,9 @@ import javax.jcr.observation.EventListener;
 @Component(service = EventListener.class, immediate = true)
 public class CustomJCREventListener extends DefaultEventListener {
 
-    Logger logger = LoggerFactory.getLogger(CustomJCREventListener.class);
-    private JahiaTemplateManagerService templateManagerService;
+    private static final Logger logger = LoggerFactory.getLogger(CustomJCREventListener.class);
 
     String[] nodetypes = new String[]{"jnt:bigText", "jnt:news"};
-
-    @Reference(service = JahiaTemplateManagerService.class)
-    public void setTemplateManagerService(JahiaTemplateManagerService templateManagerService) {
-        this.templateManagerService = templateManagerService;
-    }
-
-    @Activate
-    public void start() {
-        logger.info("Registering CustomJCREventListener in {}", templateManagerService);
-        setWorkspace(Constants.EDIT_WORKSPACE);
-        templateManagerService.getTemplatePackageRegistry().handleJCREventListener(this, true);
-    }
-
-    @Deactivate
-    public void stop() {
-        logger.info("Unregistering CustomJCREventListener from {}", templateManagerService);
-        templateManagerService.getTemplatePackageRegistry().handleJCREventListener(this, false);
-    }
 
     @Override
     public int getEventTypes() {

--- a/service-samples/pom.xml
+++ b/service-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>service-samples</artifactId>

--- a/servlet-filter-samples/pom.xml
+++ b/servlet-filter-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-filter-samples</artifactId>

--- a/servlet-filter-samples/pom.xml
+++ b/servlet-filter-samples/pom.xml
@@ -8,6 +8,7 @@
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
         <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>servlet-filter-samples</artifactId>

--- a/system-events-samples/pom.xml
+++ b/system-events-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>system-events-samples</artifactId>

--- a/validator-samples/pom.xml
+++ b/validator-samples/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.0.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.foo.modules</groupId>

--- a/workflow-sample/pom.xml
+++ b/workflow-sample/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.1.0</version>
+        <version>8.2.1.0-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.foo.modules</groupId>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-15101

## Description

Upgrade samples to the latest module parent
Due to modifications in the way JCREventListener are registered, there is no more need to do it manually.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
