### PR TITLE
QA-15101 Remove manual registration of JCR Event listeners.

### DIFF
--- a/rules-samples/pom.xml
+++ b/rules-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.0</version>
+        <version>8.2.0.0</version>
     </parent>
 
     <artifactId>rules-samples</artifactId>

--- a/rules-samples/src/main/java/org/foo/modules/rules/CustomJCREventListener.java
+++ b/rules-samples/src/main/java/org/foo/modules/rules/CustomJCREventListener.java
@@ -1,12 +1,7 @@
 package org.foo.modules.rules;
 
-import org.jahia.api.Constants;
-import org.jahia.api.templates.JahiaTemplateManagerService;
 import org.jahia.services.content.DefaultEventListener;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,27 +14,8 @@ import javax.jcr.observation.EventListener;
 public class CustomJCREventListener extends DefaultEventListener {
 
     Logger logger = LoggerFactory.getLogger(CustomJCREventListener.class);
-    private JahiaTemplateManagerService templateManagerService;
 
     String[] nodetypes = new String[]{"jnt:bigText", "jnt:news"};
-
-    @Reference(service = JahiaTemplateManagerService.class)
-    public void setTemplateManagerService(JahiaTemplateManagerService templateManagerService) {
-        this.templateManagerService = templateManagerService;
-    }
-
-    @Activate
-    public void start() {
-        logger.info("Registering CustomJCREventListener in {}", templateManagerService);
-        setWorkspace(Constants.EDIT_WORKSPACE);
-        templateManagerService.getTemplatePackageRegistry().handleJCREventListener(this, true);
-    }
-
-    @Deactivate
-    public void stop() {
-        logger.info("Unregistering CustomJCREventListener from {}", templateManagerService);
-        templateManagerService.getTemplatePackageRegistry().handleJCREventListener(this, false);
-    }
 
     @Override
     public int getEventTypes() {


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-15101

## Description

Due to modifications in the way JCREventListener are registered, there is no more need to do it manually.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
