### PR TITLE
test: fix login logout test

### DIFF
--- a/tests/cypress/e2e/loginProvider.cy.ts
+++ b/tests/cypress/e2e/loginProvider.cy.ts
@@ -19,7 +19,7 @@ describe('Login/logout url provider', () => {
         cy.visit('/start');
         getJahiaVersion().then(jahiaVersion => {
             console.log(jahiaVersion);
-            if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.2', '<')) {
+            if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.3', '<')) {
                 console.log('Test using old style primaryNavMenuButton');
                 cy.get('[role="primary-nav-control"]').click();
                 cy.contains('Sign out').click();


### PR DESCRIPTION
## Description

As we released Jahia 8220 recently, the test started to fail.
So I modified Jahia version to latest 8230 snapshot.

**Question** : do we want to keep the test compatible with older versions of Jahia ? (before 8220)
Now release nightly will be run on 8220 / snapshot nightly on 8230-SN so it will always use the "new" primary nav button.
If we don't want the test to be compatible/ runnable on older versions of Jahia 8.2.x then we can remove the `compare.version`... part --> @jayblanc ?

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
