### PR TITLE
docs: deprecate custom workflows

### DIFF
--- a/workflow-sample/README.md
+++ b/workflow-sample/README.md
@@ -3,7 +3,7 @@
 This repository contains samples of workflow registration.
 
 > [!WARNING]  
-> Custom workflows are now deprecated, and you should not base your module implementation on this sample.
+> As of Jahia 8.2.4.0, custom workflows are deprecated, and you should not base your module implementation on this sample.
 
 ## How to test it
 

--- a/workflow-sample/README.md
+++ b/workflow-sample/README.md
@@ -1,6 +1,9 @@
 # Jahia OSGi Workflow sample
 
-This repository contains samples of workflow registration
+This repository contains samples of workflow registration.
+
+> [!WARNING]  
+> Custom workflows are now deprecated, and you should not base your module implementation on this sample.
 
 ## How to test it
 

--- a/workflow-sample/pom.xml
+++ b/workflow-sample/pom.xml
@@ -15,7 +15,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Jahia Workflow samples</name>
-    <description>This is a module with Workflow samples</description>
+    <description>This is a module with Workflow samples (deprecated!)</description>
 
     <repositories>
         <repository>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->
Closes https://github.com/Jahia/jahia-private/issues/4254.

## Description

Update README to mention that custom workflows are deprecated starting Jahia 8.2.4.0.

