### PR TITLE
refactor: decouple background job from its registration

### DIFF
--- a/background-job-samples/src/main/java/org/foo/modules/jobs/TestBackgroundJob.java
+++ b/background-job-samples/src/main/java/org/foo/modules/jobs/TestBackgroundJob.java
@@ -1,54 +1,23 @@
 package org.foo.modules.jobs;
 
 import org.jahia.services.scheduler.BackgroundJob;
-import org.jahia.services.scheduler.SchedulerService;
-import org.jahia.settings.SettingsBean;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
-import org.quartz.SimpleTrigger;
-import org.quartz.Trigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Simple Background Job declared with OSGi
+ * Simple Background Job registered via {@link TestBackgroundJobRegistration}.
+ * <b>NB:</b> Note that Quartz creates instances directly, it is not possible to inject OSGi components in this job. {@link org.jahia.osgi.BundleUtils#getOsgiService(Class, String)} can be used to access OSGi components during the job execution.
  *
- * @author dgaillard
+ * @see TestBackgroundJobRegistration
  */
-@Component(immediate = true)
 public class TestBackgroundJob extends BackgroundJob {
-    private static Logger logger = LoggerFactory.getLogger(TestBackgroundJob.class);
-
-    private SchedulerService schedulerService;
-    private JobDetail jobDetail;
-
-    @Activate
-    public void start() throws Exception {
-        jobDetail = BackgroundJob.createJahiaJob("Simple background job made declared with OSGi", TestBackgroundJob.class);
-        if (schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
-            Trigger trigger = new SimpleTrigger("testBackgroundJob_trigger", jobDetail.getGroup(), SimpleTrigger.REPEAT_INDEFINITELY, 3000);
-            schedulerService.getScheduler().scheduleJob(jobDetail, trigger);
-        }
-    }
-
-    @Deactivate
-    public void stop() throws Exception {
-        if (!schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
-            schedulerService.getScheduler().deleteJob(jobDetail.getName(), jobDetail.getGroup());
-        }
-    }
+    private static final Logger logger = LoggerFactory.getLogger(TestBackgroundJob.class);
 
     @Override
     public void executeJahiaJob(JobExecutionContext jobExecutionContext) {
         logger.info("Hello Jahia!");
+        // use BundleUtils.getOsgiService(...) to access OSGi components from within this job
     }
 
-    @Reference
-    public void setSchedulerService(SchedulerService schedulerService) {
-        this.schedulerService = schedulerService;
-    }
 }

--- a/background-job-samples/src/main/java/org/foo/modules/jobs/TestBackgroundJobRegistration.java
+++ b/background-job-samples/src/main/java/org/foo/modules/jobs/TestBackgroundJobRegistration.java
@@ -1,0 +1,63 @@
+package org.foo.modules.jobs;
+
+import org.jahia.services.scheduler.BackgroundJob;
+import org.jahia.services.scheduler.SchedulerService;
+import org.jahia.settings.SettingsBean;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.quartz.JobDetail;
+import org.quartz.SimpleTrigger;
+import org.quartz.Trigger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registration of a simple background {@link TestBackgroundJob} via OSGi.<br/>
+ * <b>NB:</b> Note that only the registration of the job OSGi components, the execution itself does not have access to OSGi dependency injection.
+ *
+ * @see TestBackgroundJob
+ *
+ */
+@Component(immediate = true)
+public class TestBackgroundJobRegistration {
+    private static final Logger logger = LoggerFactory.getLogger(TestBackgroundJobRegistration.class);
+    private static final String GROUP_NAME = BackgroundJob.getGroupName(TestBackgroundJob.class);
+    private static final String JOB_NAME = "namedJob";
+
+    private SchedulerService schedulerService;
+    private JobDetail jobDetail;
+
+    @Activate
+    public void start() throws Exception {
+        // Fixed name -> can be retrieved after restart
+        jobDetail = new JobDetail(JOB_NAME, GROUP_NAME, TestBackgroundJob.class, false, true, false);
+        jobDetail.setDescription("Simple background job registered with OSGi");
+        if (SettingsBean.getInstance().isProcessingServer()) {
+            // Delete the old job at startup if exists
+            schedulerService.getScheduler().deleteJob(JOB_NAME, GROUP_NAME);
+            Trigger trigger = new SimpleTrigger("testBackgroundJob_trigger", jobDetail.getGroup(), SimpleTrigger.REPEAT_INDEFINITELY, 3000);
+            schedulerService.getScheduler().scheduleJob(jobDetail, trigger);
+            logger.info("Simple background {} job registered", jobDetail.getName());
+        }
+    }
+
+    @Deactivate
+    public void stop() throws Exception {
+        // If Jahia is shutting down, the scheduler is already stopped -> we do nothing.
+        // The job will be cleaned at the next startup. It could be found with the fixed name
+        if (schedulerService.getScheduler() == null) {
+            return;
+        }
+        if (!schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
+            schedulerService.getScheduler().deleteJob(jobDetail.getName(), jobDetail.getGroup());
+            logger.info("Simple background {} job unregistered", jobDetail.getName());
+        }
+    }
+
+    @Reference
+    public void setSchedulerService(SchedulerService schedulerService) {
+        this.schedulerService = schedulerService;
+    }
+}


### PR DESCRIPTION

## Description

Extract the registration of the `TestBackgroundJob` from the job itself.
In the registration, it is possible to inject OSGi services with `@Reference`, while the background jobs are instantiated by Quartz and therefore require to access the OSGi components via `BundleUtils.getOsgiService()`.

This change makes it clear that the `TestBackgroundJob` is **not** an OSGi component from a scheduling standpoint.